### PR TITLE
Update pyproject.toml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,8 +17,5 @@ sphinx:
 
 python:
   install:
-    - requirements: requirements.txt
     - method: pip
       path: .
-      # extra_requirements:
-      #   - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,28 +3,19 @@ name = 'asdf_website'
 description = 'The ASDF Website'
 readme = 'README.md'
 requires-python = '>=3.9'
-license = { file = 'LICENSE' }
+license-files = ['LICENSE']
 authors = [{ name = 'The ASDF Developers', email = 'help@stsci.edu' }]
 classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3.12',
     'Development Status :: 5 - Production/Stable',
 ]
 version = '0.0.0'
 dependencies = [
     'sphinx',
-    'furo',
-    'tomli',
-]
-[project.optional-dependencies]
-docs = [
     'sphinx-autobuild',
     'sphinx-copybutton',
     'sphinx-tabs',
+    'furo',
+    'tomli',
 ]
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-setuptools==70.2.0
-Sphinx==8.1.3
-sphinx-automodapi==0.18.0
-furo==2024.8.6
-graphviz==0.20.3
-sphinx-tabs==3.4.7
-sphinx-copybutton==0.5.2


### PR DESCRIPTION
This PR updates pyproject.toml to:
- fix license specifications to avoid setuptools warnings
- move "optional" requirements to always required

and also removes "requirements.txt". Is this file used anywhere? When I tried to set up a fresh environment it was ignored. EDIT: I see this is used in the docs build. I'll look to remove it (since one of the pins is triggering a github security notice).